### PR TITLE
Communicate stats from instrumentation to optimization stage

### DIFF
--- a/src/formulas/bank_conflict.py
+++ b/src/formulas/bank_conflict.py
@@ -21,9 +21,11 @@ from tracer.python.utils import run_subprocess
 
 
 class bank_conflict(Formula_Base):
-    def __init__(self, name, build_script, app_cmd):
+    def __init__(self, name, build_script, app_cmd, only_consider_top_kernel=False):
         super().__init__(name, build_script, app_cmd)
         self.profiler = "guided-tuning"
+        # This temp option allows us to toggle if we want a full or partial instrumentation report
+        self.only_consider_top_kernel = only_consider_top_kernel
 
     def profile_pass(self) -> Result:
         """
@@ -107,14 +109,12 @@ class bank_conflict(Formula_Base):
             logging.error(f"Critical Error: {output}")
             logging.error("Failed to instrument the application.")
             sys.exit(1)
+
+        bnk_conflicts_map = extract_bank_conflict_lines(output, kernel_names)
+
         return Result(
             success=True,
-            asset={
-                "kernel": "matrixTransposeShared",
-                "arguments": ["float*", "float const*", "int", "int"],
-                "lines": "17; 26",
-                "file": "../examples/bank_conflict/matrix_transpose/matrix_transpose.hip",
-            }
+            asset=bnk_conflicts_map[kernel_names[0]] if self.only_consider_top_kernel else bnk_conflicts_map
         )
 
     def optimize_pass(self, file:str, kernel:str, lines:str, temperature:float=0.0, max_tokens:int=3000) -> Result:
@@ -303,7 +303,7 @@ class bank_conflict(Formula_Base):
             log="The code is {speedup}x faster. Old code took {ref_time} seconds and the optimized code took {upd_time} seconds."
         )
     
-def generate_ecma_regex_from_list(kernel_names:list)->str:  
+def generate_ecma_regex_from_list(kernel_names:set)->str:  
     res = []
     for i in kernel_names:
         escaped_string = re.escape(i)  
@@ -322,5 +322,58 @@ def generate_ecma_regex_from_list(kernel_names:list)->str:
     return regex
 
 
+def extract_bank_conflict_lines(output:str, kernel_names:list)->dict:
+    """
+    Extract the bank conflict report from omniprobe output
 
+    Args:
+        output (str): Omniprobe output
+        kernel_names (list): List of kernel names with bank conflicts
+
+    Returns:
+        dict: Dictionary containing kernel name, arguments, file path, and line number
+    """
+    kernel_reports = {}  
+    inside_kernel_report = False  
+    current_kernel_name = None  
+    filename = None
+  
+    for line in output.splitlines():
+        if "source location:" in line:
+            filename = line.split()[2].split(':')[0]
+        if not inside_kernel_report:  
+            # Check if the line marks the start of a kernel report  
+            for kernel_sig in kernel_names:  
+                if f"Memory analysis for {kernel_sig}" in line:
+                    inside_kernel_report = True
+                    current_kernel_name = kernel_sig
+
+                    kernel_args = kernel_sig.split('(')[1].split(')')[0].split(',')
+                    kernel_reports[current_kernel_name] = {
+                        'kernel': kernel_sig.split('(')[0],
+                        'arguments': [word.strip() for word in kernel_args],
+                        'file': filename,
+                        'lines': None
+                    }  
+                    break  
+        else:  
+            # Check for the bank conflicts report  
+            if "bank conflicts for location" in line:  
+                # Extract the line number  
+                line_number = int(line.split()[4])  
+                kernel_reports[current_kernel_name]['lines'] = line_number  
+                # Exit early after finding the relevant information  
+                inside_kernel_report = False  
+                current_kernel_name = None  
+  
+            # Check for the end of the bank conflicts report  
+            if "=== End of bank conflicts report" in line:  
+                inside_kernel_report = False  
+                current_kernel_name = None  
+                filename = None
+
+    logging.debug(f"Parsed instrumentation output:\n{kernel_reports}")
+    if len(kernel_reports) == 0:
+        logging.warning("No memory analysis data parsed from instrumentation.")
+    return kernel_reports
         

--- a/src/maestro
+++ b/src/maestro
@@ -42,7 +42,12 @@ def main():
         logging.basicConfig(level=logging.WARNING)
 
     # Create an optimizer based on available Maestro formulas.
-    optimizer = bank_conflict(args.name, args.script, args.remaining)
+    optimizer = bank_conflict(
+        name=args.name, 
+        build_script=args.script, 
+        app_cmd=args.remaining,
+        only_consider_top_kernel=True
+    )
 
     # Build the application
     optimizer.build()


### PR DESCRIPTION
This PR is the tail end of #7 and removes hard-coded return statement to pass parsed instrumentation information to `run_optimization()` phase. Note that based on verbose example output we now match required schema

```console
DEBUG:root:Parsed instrumentation output:
{'bankConflictKernel(float*) [clone .kd]': {'kernel': 'bankConflictKernel', 'arguments': ['float*'], 'file': '/work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp', 'lines': 22}}
```

<details>

<summary>Example</summary>

```console
Apptainer> ls
apptainer  examples  README.md  src  tests  tracer
Apptainer> ./src/maestro -n bnk --script examples/bank_conflict/synthetic/build.sh -vv -- ./examples/bank_conflict/synthetic/bnk_conflict_inst 
rm -f bnk_conflict bnk_conflict_inst bnk_conflict.isa bnk_conflict_inst.isa
hipcc -Wno-unused-result -I /opt/logduration/include/kerneldb -I /opt/logduration/include/dh_comms -I /opt/rocm/include/hsa -O3 -g -o bnk_conflict bnk_conflict.cpp
hipcc -Wno-unused-result -I /opt/logduration/include/kerneldb -I /opt/logduration/include/dh_comms -I /opt/rocm/include/hsa -fgpu-rdc -fpass-plugin=/opt/logduration/lib/libAMDGCNMemTraceHip.so -O3 -g -o bnk_conflict_inst bnk_conflict.cpp
Injecting Mem Trace Function Into AMDGPU Kernel: __amd_crk__Z18bankConflictKernelPfPv     /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp:12:14
0     __amd_crk__Z18bankConflictKernelPfPv     /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp:12:14     SHARED     STORE
Injecting Mem Trace Function Into AMDGPU Kernel: __amd_crk__Z18bankConflictKernelPfPv     /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp:22:19
1     __amd_crk__Z18bankConflictKernelPfPv     /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp:22:19     SHARED     LOAD
Injecting Mem Trace Function Into AMDGPU Kernel: __amd_crk__Z18bankConflictKernelPfPv     /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp:23:16
2     __amd_crk__Z18bankConflictKernelPfPv     /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp:23:16     GLOBAL     STORE

__                                       _
_ __ ___   ___ _ __  _ __ ___  / _|       ___ ___  _ __ ___  _ __  _   _| |_ ___
| '__/ _ \ / __| '_ \| '__/ _ \| |_ _____ / __/ _ \| '_ ` _ \| '_ \| | | | __/ _ \
| | | (_) | (__| |_) | | | (_) |  _|_____| (_| (_) | | | | | | |_) | |_| | ||  __/
|_|  \___/ \___| .__/|_|  \___/|_|        \___\___/|_| |_| |_| .__/ \__,_|\__\___|
|_|                                           |_|

INFO Rocprofiler-Compute version: 3.0.0
INFO Profiler choice: rocprofv1
INFO Path: /root/guided-tuning/workloads/bnk/MI200
INFO Target: MI200
INFO Command: /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict_inst
INFO Kernel Selection: None
INFO Dispatch Selection: None
INFO Hardware Blocks: All
INFO
INFO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO Collecting Performance Counters
INFO ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
INFO

...

Detected Kernels (sorted descending by duration)
╒════╤════════════════════════════════════════╕
│    │ Kernel_Name                            │
╞════╪════════════════════════════════════════╡
│  0 │ bankConflictKernel(float*) [clone .kd] │
╘════╧════════════════════════════════════════╛

--------------------------------------------------------------------------------
Dispatch list
╒════╤═══════════════╤════════════════════════════════════════╤══════════╕
│    │   Dispatch_ID │ Kernel_Name                            │   GPU_ID │
╞════╪═══════════════╪════════════════════════════════════════╪══════════╡
│  0 │             0 │ bankConflictKernel(float*) [clone .kd] │        2 │
╘════╧═══════════════╧════════════════════════════════════════╧══════════╛
Initializing Database...
Loading workload(workloads/bnk/MI200) ...
Loading workloads/bnk/MI200/pmc_perf.csv ...
Loading workloads/bnk/MI200/SQ_INST_LEVEL_LDS.csv ...
Loading workloads/bnk/MI200/SQ_INST_LEVEL_VMEM.csv ...
Loading workloads/bnk/MI200/SQ_INST_LEVEL_SMEM.csv ...
Loading workloads/bnk/MI200/SQ_IFETCH_LEVEL.csv ...
Loading workloads/bnk/MI200/SQ_LEVEL_WAVES.csv ...
1,105 metrics loaded.

real    0m0.739s
1    bnk

DEBUG:root:Matching DB Workloads: {'1': 'bnk'}
╒════════════════════════════════════╤══════════════════════════════════════════════════════════════════════════════════════════╤═════════════╕
│             Timestamp              │                                         Command                                          │  GPU Model  │
DEBUG:root:Filtered Report Card:
   Count  Avg-Duration  Percentage  LDS Bank Conflicts                                  Kernel
0      1        3040.0       100.0                  56  bankConflictKernel(float*) [clone .kd]
DEBUG:root:ECMA Regex for kernel names: (^bankConflictKernel\(float\*\)\ \[clone\ \.kd\]$|^__amd_crk_bankConflictKernel\(float\*,\ void\*\)\ \[clone\ \.kd\]$)
WARNING:root:HANDLER: libMemAnalysis64.so
WARNING:root:kernel,dispatch,startNs,endNs
WARNING:root:Adding /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict_inst
WARNING:root:Adding linux-vdso.so.1
WARNING:root:Adding /opt/rocm/lib/libamdhip64.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libstdc++.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libm.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libgcc_s.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libc.so.6
WARNING:root:Adding /opt/rocm/lib/librocprofiler-register.so.0
WARNING:root:Adding /opt/rocm/lib/libamd_comgr.so.2
WARNING:root:Adding /opt/rocm/lib/libhsa-runtime64.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libnuma.so.1
WARNING:root:Adding /lib64/ld-linux-x86-64.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libz.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libzstd.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libelf.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm_amdgpu.so.1
WARNING:root:Adding /opt/logduration/lib/logDuration/liblogDuration64.so
WARNING:root:Adding /opt/logduration/lib/libdh_comms.so
WARNING:root:You're adding kernel ".text" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_pure_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_deleted_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_message" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_time_interval" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_address" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_message" which we've seen before. Something may be wrong.
WARNING:root:Adding /opt/logduration/lib/libkernelDB64.so.1
WARNING:root:Adding /opt/logduration/lib/libMemAnalysis64.so
WARNING:root:Adding /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict_inst
WARNING:root:Adding linux-vdso.so.1
WARNING:root:Adding /opt/rocm/lib/libamdhip64.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libstdc++.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libm.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libgcc_s.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libc.so.6
WARNING:root:Adding /opt/rocm/lib/librocprofiler-register.so.0
WARNING:root:Adding /opt/rocm/lib/libamd_comgr.so.2
WARNING:root:Adding /opt/rocm/lib/libhsa-runtime64.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libnuma.so.1
WARNING:root:Adding /lib64/ld-linux-x86-64.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libz.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libzstd.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libelf.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm_amdgpu.so.1
WARNING:root:Adding /opt/logduration/lib/logDuration/liblogDuration64.so
WARNING:root:Adding /opt/logduration/lib/libdh_comms.so
WARNING:root:You're adding kernel ".text" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_pure_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_deleted_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_message" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_time_interval" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_address" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_message" which we've seen before. Something may be wrong.
WARNING:root:Adding /opt/logduration/lib/libkernelDB64.so.1
WARNING:root:Adding /opt/logduration/lib/libMemAnalysis64.so
WARNING:root:Adding /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict_inst
WARNING:root:Adding linux-vdso.so.1
WARNING:root:Adding /opt/rocm/lib/libamdhip64.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libstdc++.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libm.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libgcc_s.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libc.so.6
WARNING:root:Adding /opt/rocm/lib/librocprofiler-register.so.0
WARNING:root:Adding /opt/rocm/lib/libamd_comgr.so.2
WARNING:root:Adding /opt/rocm/lib/libhsa-runtime64.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libnuma.so.1
WARNING:root:Adding /lib64/ld-linux-x86-64.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libz.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libzstd.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libelf.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm_amdgpu.so.1
WARNING:root:Adding /opt/logduration/lib/logDuration/liblogDuration64.so
WARNING:root:Adding /opt/logduration/lib/libdh_comms.so
WARNING:root:You're adding kernel ".text" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_pure_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_deleted_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_message" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_time_interval" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_address" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_message" which we've seen before. Something may be wrong.
WARNING:root:Adding /opt/logduration/lib/libkernelDB64.so.1
WARNING:root:Adding /opt/logduration/lib/libMemAnalysis64.so
WARNING:root:Adding /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict_inst
WARNING:root:Adding linux-vdso.so.1
WARNING:root:Adding /opt/rocm/lib/libamdhip64.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libstdc++.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libm.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libgcc_s.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libc.so.6
WARNING:root:Adding /opt/rocm/lib/librocprofiler-register.so.0
WARNING:root:Adding /opt/rocm/lib/libamd_comgr.so.2
WARNING:root:Adding /opt/rocm/lib/libhsa-runtime64.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libnuma.so.1
WARNING:root:Adding /lib64/ld-linux-x86-64.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libz.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libzstd.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libelf.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm_amdgpu.so.1
WARNING:root:Adding /opt/logduration/lib/logDuration/liblogDuration64.so
WARNING:root:Adding /opt/logduration/lib/libdh_comms.so
WARNING:root:You're adding kernel ".text" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_pure_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_deleted_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_message" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_time_interval" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_address" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_message" which we've seen before. Something may be wrong.
WARNING:root:Adding /opt/logduration/lib/libkernelDB64.so.1
WARNING:root:Adding /opt/logduration/lib/libMemAnalysis64.so
WARNING:root:Adding /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict_inst
WARNING:root:Adding linux-vdso.so.1
WARNING:root:Adding /opt/rocm/lib/libamdhip64.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libstdc++.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libm.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libgcc_s.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libc.so.6
WARNING:root:Adding /opt/rocm/lib/librocprofiler-register.so.0
WARNING:root:Adding /opt/rocm/lib/libamd_comgr.so.2
WARNING:root:Adding /opt/rocm/lib/libhsa-runtime64.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libnuma.so.1
WARNING:root:Adding /lib64/ld-linux-x86-64.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libz.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libzstd.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libelf.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm_amdgpu.so.1
WARNING:root:Adding /opt/logduration/lib/logDuration/liblogDuration64.so
WARNING:root:Adding /opt/logduration/lib/libdh_comms.so
WARNING:root:You're adding kernel ".text" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_pure_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_deleted_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_message" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_time_interval" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_address" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_message" which we've seen before. Something may be wrong.
WARNING:root:Adding /opt/logduration/lib/libkernelDB64.so.1
WARNING:root:Adding /opt/logduration/lib/libMemAnalysis64.so
WARNING:root:Adding /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict_inst
WARNING:root:Adding linux-vdso.so.1
WARNING:root:Adding /opt/rocm/lib/libamdhip64.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libstdc++.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libm.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libgcc_s.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libc.so.6
WARNING:root:Adding /opt/rocm/lib/librocprofiler-register.so.0
WARNING:root:Adding /opt/rocm/lib/libamd_comgr.so.2
WARNING:root:Adding /opt/rocm/lib/libhsa-runtime64.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libnuma.so.1
WARNING:root:Adding /lib64/ld-linux-x86-64.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libz.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libzstd.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libelf.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm_amdgpu.so.1
WARNING:root:Adding /opt/logduration/lib/logDuration/liblogDuration64.so
WARNING:root:Adding /opt/logduration/lib/libdh_comms.so
WARNING:root:You're adding kernel ".text" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_pure_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_deleted_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_message" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_time_interval" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_address" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_message" which we've seen before. Something may be wrong.
WARNING:root:Adding /opt/logduration/lib/libkernelDB64.so.1
WARNING:root:Adding /opt/logduration/lib/libMemAnalysis64.so
WARNING:root:Adding /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict_inst
WARNING:root:Adding linux-vdso.so.1
WARNING:root:Adding /opt/rocm/lib/libamdhip64.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libstdc++.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libm.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libgcc_s.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libc.so.6
WARNING:root:Adding /opt/rocm/lib/librocprofiler-register.so.0
WARNING:root:Adding /opt/rocm/lib/libamd_comgr.so.2
WARNING:root:Adding /opt/rocm/lib/libhsa-runtime64.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libnuma.so.1
WARNING:root:Adding /lib64/ld-linux-x86-64.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libz.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libzstd.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libelf.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm_amdgpu.so.1
WARNING:root:Adding /opt/logduration/lib/logDuration/liblogDuration64.so
WARNING:root:Adding /opt/logduration/lib/libdh_comms.so
WARNING:root:You're adding kernel ".text" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_pure_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_deleted_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_message" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_time_interval" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_address" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_message" which we've seen before. Something may be wrong.
WARNING:root:Adding /opt/logduration/lib/libkernelDB64.so.1
WARNING:root:Adding /opt/logduration/lib/libMemAnalysis64.so
WARNING:root:Adding /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict_inst
WARNING:root:Adding linux-vdso.so.1
WARNING:root:Adding /opt/rocm/lib/libamdhip64.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libstdc++.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libm.so.6
WARNING:root:Adding /lib/x86_64-linux-gnu/libgcc_s.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libc.so.6
WARNING:root:Adding /opt/rocm/lib/librocprofiler-register.so.0
WARNING:root:Adding /opt/rocm/lib/libamd_comgr.so.2
WARNING:root:Adding /opt/rocm/lib/libhsa-runtime64.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libnuma.so.1
WARNING:root:Adding /lib64/ld-linux-x86-64.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libz.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libzstd.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libelf.so.1
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm.so.2
WARNING:root:Adding /lib/x86_64-linux-gnu/libdrm_amdgpu.so.1
WARNING:root:Adding /opt/logduration/lib/logDuration/liblogDuration64.so
WARNING:root:Adding /opt/logduration/lib/libdh_comms.so
WARNING:root:You're adding kernel ".text" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_pure_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "__cxa_deleted_virtual" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_message" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "s_submit_time_interval" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_address" which we've seen before. Something may be wrong.
WARNING:root:You're adding kernel "v_submit_message" which we've seen before. Something may be wrong.
WARNING:root:Adding /opt/logduration/lib/libkernelDB64.so.1
WARNING:root:Adding /opt/logduration/lib/libMemAnalysis64.so
WARNING:root:>>>>>>>> HSA intercept registered.
WARNING:root:"bankConflictKernel(float*) [clone .kd]",2013598109659595,2013598109671091,2013598110029171
WARNING:root:---
WARNING:root:From IR instrumentation: dwarf_fname_hash = 0x8ce541392c466d71, line = 23, column = 16
WARNING:root:Kernel: bankConflictKernel(float*) Instruction Count for line 23 == 1
WARNING:root:Checking global_store_dword...
WARNING:root:source location: /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp:23:16
WARNING:root:dwarf_fname_hash = 0x8ce541392c466d71
WARNING:root:---
WARNING:root:From IR instrumentation: dwarf_fname_hash = 0x8ce541392c466d71, line = 23, column = 16
WARNING:root:Kernel: bankConflictKernel(float*) Instruction Count for line 23 == 1
WARNING:root:Checking global_store_dword...
WARNING:root:source location: /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp:23:16
WARNING:root:dwarf_fname_hash = 0x8ce541392c466d71
WARNING:root:---
WARNING:root:From IR instrumentation: dwarf_fname_hash = 0x8ce541392c466d71, line = 23, column = 16
WARNING:root:Kernel: bankConflictKernel(float*) Instruction Count for line 23 == 1
WARNING:root:Checking global_store_dword...
WARNING:root:source location: /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp:23:16
WARNING:root:dwarf_fname_hash = 0x8ce541392c466d71
WARNING:root:---
WARNING:root:From IR instrumentation: dwarf_fname_hash = 0x8ce541392c466d71, line = 23, column = 16
WARNING:root:Kernel: bankConflictKernel(float*) Instruction Count for line 23 == 1
WARNING:root:Checking global_store_dword...
WARNING:root:source location: /work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp:23:16
WARNING:root:dwarf_fname_hash = 0x8ce541392c466d71
WARNING:root:Memory analysis for bankConflictKernel(float*) [clone .kd] dispatch_id[1]
WARNING:root:=== L2 cache line use report ======================
WARNING:root:No excess cache lines used for global memory accesses
WARNING:root:=== End of L2 cache line use report ===============
WARNING:root:=== Bank conflicts report =========================
WARNING:root:bank conflicts for location 22
WARNING:root:read of 4 bytes/lane: executed 4 times, 56 total bank conflict(s)
WARNING:root:=== End of bank conflicts report ====================
WARNING:root:9984 bytes processed in 0.000900 seconds (11.1 MiB/s)
WARNING:root:~memory_analysis_handler()
WARNING:root:h_out[0] = 0
WARNING:root:h_out[1] = 64
WARNING:root:h_out[2] = 128
WARNING:root:h_out[3] = 192
WARNING:root:h_out[4] = 256
WARNING:root:h_out[5] = 320
WARNING:root:h_out[6] = 384
WARNING:root:h_out[7] = 448
WARNING:root:h_out[8] = 0
WARNING:root:h_out[9] = 64
WARNING:root:h_out[10] = 128
WARNING:root:h_out[11] = 192
WARNING:root:h_out[12] = 256
WARNING:root:h_out[13] = 320
WARNING:root:h_out[14] = 384
WARNING:root:h_out[15] = 448
WARNING:root:h_out[16] = 0
WARNING:root:h_out[17] = 64
WARNING:root:h_out[18] = 128
WARNING:root:h_out[19] = 192
WARNING:root:h_out[20] = 256
WARNING:root:h_out[21] = 320
WARNING:root:h_out[22] = 384
WARNING:root:h_out[23] = 448
WARNING:root:h_out[24] = 0
WARNING:root:h_out[25] = 64
WARNING:root:h_out[26] = 128
WARNING:root:h_out[27] = 192
WARNING:root:h_out[28] = 256
WARNING:root:h_out[29] = 320
WARNING:root:h_out[30] = 384
WARNING:root:h_out[31] = 448
WARNING:root:h_out[32] = 0
WARNING:root:h_out[33] = 64
WARNING:root:h_out[34] = 128
WARNING:root:h_out[35] = 192
WARNING:root:h_out[36] = 256
WARNING:root:h_out[37] = 320
WARNING:root:h_out[38] = 384
WARNING:root:h_out[39] = 448
WARNING:root:h_out[40] = 0
WARNING:root:h_out[41] = 64
WARNING:root:h_out[42] = 128
WARNING:root:h_out[43] = 192
WARNING:root:h_out[44] = 256
WARNING:root:h_out[45] = 320
WARNING:root:h_out[46] = 384
WARNING:root:h_out[47] = 448
WARNING:root:h_out[48] = 0
WARNING:root:h_out[49] = 64
WARNING:root:h_out[50] = 128
WARNING:root:h_out[51] = 192
WARNING:root:h_out[52] = 256
WARNING:root:h_out[53] = 320
WARNING:root:h_out[54] = 384
WARNING:root:h_out[55] = 448
WARNING:root:h_out[56] = 0
WARNING:root:h_out[57] = 64
WARNING:root:h_out[58] = 128
WARNING:root:h_out[59] = 192
WARNING:root:h_out[60] = 256
WARNING:root:h_out[61] = 320
WARNING:root:h_out[62] = 384
WARNING:root:h_out[63] = 448
WARNING:root:h_out[64] = 0
WARNING:root:h_out[65] = 64
WARNING:root:h_out[66] = 128
WARNING:root:h_out[67] = 192
WARNING:root:h_out[68] = 256
WARNING:root:h_out[69] = 320
WARNING:root:h_out[70] = 384
WARNING:root:h_out[71] = 448
WARNING:root:h_out[72] = 0
WARNING:root:h_out[73] = 64
WARNING:root:h_out[74] = 128
WARNING:root:h_out[75] = 192
WARNING:root:h_out[76] = 256
WARNING:root:h_out[77] = 320
WARNING:root:h_out[78] = 384
WARNING:root:h_out[79] = 448
WARNING:root:h_out[80] = 0
WARNING:root:h_out[81] = 64
WARNING:root:h_out[82] = 128
WARNING:root:h_out[83] = 192
WARNING:root:h_out[84] = 256
WARNING:root:h_out[85] = 320
WARNING:root:h_out[86] = 384
WARNING:root:h_out[87] = 448
WARNING:root:h_out[88] = 0
WARNING:root:h_out[89] = 64
WARNING:root:h_out[90] = 128
WARNING:root:h_out[91] = 192
WARNING:root:h_out[92] = 256
WARNING:root:h_out[93] = 320
WARNING:root:h_out[94] = 384
WARNING:root:h_out[95] = 448
WARNING:root:h_out[96] = 0
WARNING:root:h_out[97] = 64
WARNING:root:h_out[98] = 128
WARNING:root:h_out[99] = 192
WARNING:root:h_out[100] = 256
WARNING:root:h_out[101] = 320
WARNING:root:h_out[102] = 384
WARNING:root:h_out[103] = 448
WARNING:root:h_out[104] = 0
WARNING:root:h_out[105] = 64
WARNING:root:h_out[106] = 128
WARNING:root:h_out[107] = 192
WARNING:root:h_out[108] = 256
WARNING:root:h_out[109] = 320
WARNING:root:h_out[110] = 384
WARNING:root:h_out[111] = 448
WARNING:root:h_out[112] = 0
WARNING:root:h_out[113] = 64
WARNING:root:h_out[114] = 128
WARNING:root:h_out[115] = 192
WARNING:root:h_out[116] = 256
WARNING:root:h_out[117] = 320
WARNING:root:h_out[118] = 384
WARNING:root:h_out[119] = 448
WARNING:root:h_out[120] = 0
WARNING:root:h_out[121] = 64
WARNING:root:h_out[122] = 128
WARNING:root:h_out[123] = 192
WARNING:root:h_out[124] = 256
WARNING:root:h_out[125] = 320
WARNING:root:h_out[126] = 384
WARNING:root:h_out[127] = 448
WARNING:root:h_out[128] = 0
WARNING:root:h_out[129] = 64
WARNING:root:h_out[130] = 128
WARNING:root:h_out[131] = 192
WARNING:root:h_out[132] = 256
WARNING:root:h_out[133] = 320
WARNING:root:h_out[134] = 384
WARNING:root:h_out[135] = 448
WARNING:root:h_out[136] = 0
WARNING:root:h_out[137] = 64
WARNING:root:h_out[138] = 128
WARNING:root:h_out[139] = 192
WARNING:root:h_out[140] = 256
WARNING:root:h_out[141] = 320
WARNING:root:h_out[142] = 384
WARNING:root:h_out[143] = 448
WARNING:root:h_out[144] = 0
WARNING:root:h_out[145] = 64
WARNING:root:h_out[146] = 128
WARNING:root:h_out[147] = 192
WARNING:root:h_out[148] = 256
WARNING:root:h_out[149] = 320
WARNING:root:h_out[150] = 384
WARNING:root:h_out[151] = 448
WARNING:root:h_out[152] = 0
WARNING:root:h_out[153] = 64
WARNING:root:h_out[154] = 128
WARNING:root:h_out[155] = 192
WARNING:root:h_out[156] = 256
WARNING:root:h_out[157] = 320
WARNING:root:h_out[158] = 384
WARNING:root:h_out[159] = 448
WARNING:root:h_out[160] = 0
WARNING:root:h_out[161] = 64
WARNING:root:h_out[162] = 128
WARNING:root:h_out[163] = 192
WARNING:root:h_out[164] = 256
WARNING:root:h_out[165] = 320
WARNING:root:h_out[166] = 384
WARNING:root:h_out[167] = 448
WARNING:root:h_out[168] = 0
WARNING:root:h_out[169] = 64
WARNING:root:h_out[170] = 128
WARNING:root:h_out[171] = 192
WARNING:root:h_out[172] = 256
WARNING:root:h_out[173] = 320
WARNING:root:h_out[174] = 384
WARNING:root:h_out[175] = 448
WARNING:root:h_out[176] = 0
WARNING:root:h_out[177] = 64
WARNING:root:h_out[178] = 128
WARNING:root:h_out[179] = 192
WARNING:root:h_out[180] = 256
WARNING:root:h_out[181] = 320
WARNING:root:h_out[182] = 384
WARNING:root:h_out[183] = 448
WARNING:root:h_out[184] = 0
WARNING:root:h_out[185] = 64
WARNING:root:h_out[186] = 128
WARNING:root:h_out[187] = 192
WARNING:root:h_out[188] = 256
WARNING:root:h_out[189] = 320
WARNING:root:h_out[190] = 384
WARNING:root:h_out[191] = 448
WARNING:root:h_out[192] = 0
WARNING:root:h_out[193] = 64
WARNING:root:h_out[194] = 128
WARNING:root:h_out[195] = 192
WARNING:root:h_out[196] = 256
WARNING:root:h_out[197] = 320
WARNING:root:h_out[198] = 384
WARNING:root:h_out[199] = 448
WARNING:root:h_out[200] = 0
WARNING:root:h_out[201] = 64
WARNING:root:h_out[202] = 128
WARNING:root:h_out[203] = 192
WARNING:root:h_out[204] = 256
WARNING:root:h_out[205] = 320
WARNING:root:h_out[206] = 384
WARNING:root:h_out[207] = 448
WARNING:root:h_out[208] = 0
WARNING:root:h_out[209] = 64
WARNING:root:h_out[210] = 128
WARNING:root:h_out[211] = 192
WARNING:root:h_out[212] = 256
WARNING:root:h_out[213] = 320
WARNING:root:h_out[214] = 384
WARNING:root:h_out[215] = 448
WARNING:root:h_out[216] = 0
WARNING:root:h_out[217] = 64
WARNING:root:h_out[218] = 128
WARNING:root:h_out[219] = 192
WARNING:root:h_out[220] = 256
WARNING:root:h_out[221] = 320
WARNING:root:h_out[222] = 384
WARNING:root:h_out[223] = 448
WARNING:root:h_out[224] = 0
WARNING:root:h_out[225] = 64
WARNING:root:h_out[226] = 128
WARNING:root:h_out[227] = 192
WARNING:root:h_out[228] = 256
WARNING:root:h_out[229] = 320
WARNING:root:h_out[230] = 384
WARNING:root:h_out[231] = 448
WARNING:root:h_out[232] = 0
WARNING:root:h_out[233] = 64
WARNING:root:h_out[234] = 128
WARNING:root:h_out[235] = 192
WARNING:root:h_out[236] = 256
WARNING:root:h_out[237] = 320
WARNING:root:h_out[238] = 384
WARNING:root:h_out[239] = 448
WARNING:root:h_out[240] = 0
WARNING:root:h_out[241] = 64
WARNING:root:h_out[242] = 128
WARNING:root:h_out[243] = 192
WARNING:root:h_out[244] = 256
WARNING:root:h_out[245] = 320
WARNING:root:h_out[246] = 384
WARNING:root:h_out[247] = 448
WARNING:root:h_out[248] = 0
WARNING:root:h_out[249] = 64
WARNING:root:h_out[250] = 128
WARNING:root:h_out[251] = 192
WARNING:root:h_out[252] = 256
WARNING:root:h_out[253] = 320
WARNING:root:h_out[254] = 384
WARNING:root:h_out[255] = 448
WARNING:root:signal_runner is shutting down
WARNING:root:Comms Runner shutting down
WARNING:root:Cache Watcher shutting down
Found config file at /opt/logduration/bin/logDuration/runtime_config.txt

DEBUG:root:Parsed instrumentation output:
{'bankConflictKernel(float*) [clone .kd]': {'kernel': 'bankConflictKernel', 'arguments': ['float*'], 'file': '/work1/amd/colramos/audacious/maestro/examples/bank_conflict/synthetic/bnk_conflict.cpp', 'lines': 22}}
INFO:root:
ERROR:root:Error: Missing OpenAI API key.
```

</details>