### PR TITLE
Update `pyproject.toml` repos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ python3 -m pip install -r requirements.txt
 
 [tool.guided-tuning]
 git = "git@github.com:AMDResearch/guided-tuning.git"
-branch = "7a2f4d06de6ecedceaec83a44ea010988ec5ff28"
+branch = "c8f4ef035c8ea81c0821798a0c956305a16ebc32"
 build_command = """
 python3 -m pip install -r requirements.txt
 """


### PR DESCRIPTION
Since the last commit to this file a few things have changed and need updating.

- Dependencies should be pulled from their new `AMDResearch` repos
- Feature branch being used for logduration was upstreamed and removed. Change this to main and stub commit ID
- We no longer need to build from a custom rocprof-compute fork. Change this and stub commit ID