### PR TITLE
Update Apptainer build to match pyproject.toml install as in Dockerfile

### DIFF
--- a/apptainer/build.sh
+++ b/apptainer/build.sh
@@ -23,47 +23,30 @@
 # SOFTWARE.
 ################################################################################
 
-debug=0
+# Script directories
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+parent_dir="$(dirname "$script_dir")"
+cur_dir=$(pwd)
 
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        -d|--debug)
-            debug=1
-            shift
-            ;;
-        *)
-            echo "Usage: $0 [-d|--debug]"
-            exit 1
-            ;;
-    esac
-done
+maestro_home="/maestro"
 
+pushd "$script_dir"
 
-# Auto config SSH agent
+# Auto-configure SSH agent
 if [ ! -S ~/.ssh/ssh_auth_sock ]; then
-    eval `ssh-agent` > /dev/null
+    eval "$(ssh-agent)" > /dev/null
     ln -sf "$SSH_AUTH_SOCK" ~/.ssh/ssh_auth_sock
 fi
 export SSH_AUTH_SOCK=~/.ssh/ssh_auth_sock
+ssh_auth_sock_path=$(readlink -f "$SSH_AUTH_SOCK")
+
+# Add default keys if they exist
 [ -f ~/.ssh/id_rsa ] && ssh-add ~/.ssh/id_rsa
 [ -f ~/.ssh/id_ed25519 ] && ssh-add ~/.ssh/id_ed25519
+[ -f ~/.ssh/id_github ] && ssh-add ~/.ssh/id_github
 
-ssh_auth_sock_path=$(readlink -f "$SSH_AUTH_SOCK")
-# Build the Singularity container
-#   --build-arg SSH_AUTH_SOCK=$SSH_AUTH_SOCK is used to pass the SSH agent socket to the container
-#   (advantage of this method is that the key is at no point copied to the container image.)
-#   If your SSH_AUTH_SOCK will not already bound to the container, and is available at /run/..., add `--bind /run` to the build command
-definition="apptainer/intelliperf.def"
-
-if [[ $debug -eq 1 ]]; then
-    image="apptainer/intelliperf_debug.sif"
-    cmake_build_type="Debug"
-else
-    image="apptainer/intelliperf.sif"
-    cmake_build_type="Release"
-fi
 
 apptainer build \
+    --build-arg MAESTRO_HOME=${maestro_home} \
     --build-arg SSH_AUTH_SOCK=${ssh_auth_sock_path} \
-    --build-arg CMAKE_BUILD_TYPE=${cmake_build_type}\
-     $image $definition
+    "$script_dir/intelliperf.sif" "$script_dir/intelliperf.def"

--- a/apptainer/intelliperf.def
+++ b/apptainer/intelliperf.def
@@ -1,12 +1,11 @@
 Bootstrap: docker
-From: ubuntu:22.04
+From: rocm/vllm-dev:nightly_aiter_integration_final_20250325
 
 %environment
-    # Locale
+    # Runtime environment inside the finished SIF
     export LANG=en_US.UTF-8
-
-    # ROCm globals
     export PATH=/opt/rocm/bin:$PATH
+<<<<<<< HEAD:apptainer/intelliperf.def
     export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
     export ROCM_PATH=/opt/rocm
 
@@ -17,82 +16,43 @@ From: ubuntu:22.04
 
 %files
     examples/bank_conflict/llm.c/requirements.txt /examples/bank_conflict/llm.c/requirements.txt
+=======
+    export MAESTRO_HOME={{ MAESTRO_HOME }}
+>>>>>>> 09ff03f (Update Apptainer build to match pyproject.toml install as in Dockerfile):apptainer/maestro.def
 
 %post
-    # Set locale
-    apt-get -y update
-    apt-get install -y locales
-    locale-gen en_US.UTF-8
-    export LANG=en_US.UTF-8
+    PATH=/opt/rocm/bin:$PATH
+    DEV_MODE={{ DEV_MODE }}
+    MAESTRO_HOME={{ MAESTRO_HOME }}
 
-    # Install dependencies
-    apt-get -y update
-    apt-get install -y software-properties-common
-    apt-get upgrade -y
-    apt-get install -y build-essential python3 python3-pip python3-setuptools python3-wheel git wget clang lld libzstd-dev libomp-dev vim libdwarf-dev
-    apt-get install -y locales
-    locale-gen en_US.UTF-8
-    python3 -m pip install --upgrade pip
-    python3 -m pip install 'cmake==3.22'
+    mkdir -p "${MAESTRO_HOME}"
+    # ----- 1. Packages -------------------------------------------------------
+    apt-get update
+    apt-get install -y --no-install-recommends \
+        libzstd-dev \
+        python3-setuptools \
+        python3-wheel \
+        libdwarf-dev \
+        rocm-llvm-dev \
+        locales \
+        gdb \
+        ssh
+    locale-gen en_US.UTF-8 
+    rm -rf /var/lib/apt/lists/*
 
-    # Add GitHub trusted host
+    # ----- 2. Prepare SSH known_hosts for GitHub cloning ---------------------
     mkdir -p ~/.ssh
     touch ~/.ssh/known_hosts
     ssh-keyscan github.com >> ~/.ssh/known_hosts
     chmod 700 ~/.ssh
     chmod 644 ~/.ssh/known_hosts
-
-    # Install ROCm
-    apt-get -y update
-    wget https://repo.radeon.com/amdgpu-install/6.3.3/ubuntu/jammy/amdgpu-install_6.3.60303-1_all.deb
-    apt-get -y install ./amdgpu-install_6.3.60303-1_all.deb
-    apt-get -y update
-    apt-get install -y rocm-dev rocm-llvm-dev rocm-hip-runtime-dev rocm-smi-lib rocminfo rocthrust-dev rocprofiler-compute rocblas rocm-gdb gdb tmux
-    export PATH=/opt/rocm/bin:$PATH
-    export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
-    export ROCM_PATH=/opt/rocm
-
-    # Install rocprof-compute (via package manager)
-    # python3 -m pip install --ignore-installed blinker
-    # python3 -m pip install -r /opt/rocm/libexec/rocprofiler-compute/requirements.txt
-    # Install rocprof-compute (from feature branch)
     export SSH_AUTH_SOCK={{ SSH_AUTH_SOCK }}
-    cd /root
-    git clone -v https://github.com/ROCm/rocprofiler-compute.git
-    cd rocprofiler-compute
-    git checkout 41e73650d5cfc3dbd98e007d6279235578f8529a
-    python3 -m pip install --ignore-installed blinker
-    python3 -m pip install -r requirements.txt
-    cd src
-    export PATH=$PWD:$PATH
 
-    # Install Triton (version pinned)
-    cd /root
-    export TRITON_HOME=/root
-    git clone -v https://github.com/triton-lang/triton.git
-    cd triton
-    git checkout 6fa33ef1eecc97348d056688df84845db7d22507
-    python3 -m pip install ninja wheel pybind11
-    python3 -m pip install -e python
-
-    # Install omniprobe
-    echo "Building with CMAKE_BUILD_TYPE={{ CMAKE_BUILD_TYPE }}"
-    cd /root
-    git clone -v git@github.com:AARInternal/omniprobe.git
-    cd omniprobe
-    git checkout 8e63827f1cd17077cdf13aef7177eb311cc2c896
-    git submodule update --init --recursive
-    mkdir -p build 
-    cmake -DCMAKE_INSTALL_PREFIX=/opt/omniprobe\
-            -DCMAKE_PREFIX_PATH=${ROCM_PATH}\
-            -DTRITON_LLVM=/root/.triton/llvm/llvm-ubuntu-x64\
-            -DCMAKE_BUILD_TYPE={{ CMAKE_BUILD_TYPE }}\
-            -DCMAKE_VERBOSE_MAKEFILE=ON -S . -B build
-    cmake --build build --target install
-    export PATH=/opt/omniprobe/bin/logDuration:$PATH
-
-    # Install agents dependencies
-    python3 -m pip install openai
-
-    # Install examples dependencies
-    pip3 install --no-cache-dir -r /examples/bank_conflict/llm.c/requirements.txt
+    # ----- 3. Clone & install Maestro only if DEV_MODE == false --------------
+    cd "${MAESTRO_HOME}"
+    # During `apptainer build`, the host’s SSH agent keys are available if
+    # you run:  `APPTAINER_SSH=true apptainer build …`
+    git clone git@github.com:AMDResearch/maestro.git .
+    
+    pip install -e .
+    python3 scripts/install_tool.py --all

--- a/apptainer/run.sh
+++ b/apptainer/run.sh
@@ -38,12 +38,8 @@ while [[ $# -gt 0 ]]; do
             size=$2
             shift 2
             ;;
-        -d|--debug)
-            debug=1
-            shift
-            ;;
         *)
-            echo "Usage: $0 [-s size] [-d|--debug]"
+            echo "Usage: $0 [-s size]"
             exit 1
             ;;
     esac
@@ -59,9 +55,5 @@ fi
 echo "[Log] Utilize the directory /var/cache/intelliperf as a sandbox to store data you'd like to persist between container runs."
 
 # Run the container
-if [[ $debug -eq 1 ]]; then
-    image="apptainer/intelliperf_debug.sif"
-else
-    image="apptainer/intelliperf.sif"
-fi
-apptainer exec --bind $HOME/.ssh:/root/.ssh:ro --overlay ${overlay} --pwd "$working_dir" --cleanenv --env OPENAI_API_KEY=$OPENAI_API_KEY $image bash --rcfile /etc/bash.bashrc
+image="apptainer/intelliperf.sif"
+apptainer exec --overlay ${overlay} --pwd "$working_dir" --cleanenv --env OPENAI_API_KEY=$OPENAI_API_KEY $image bash --rcfile /etc/bash.bashrc


### PR DESCRIPTION
The Dockerfile uses `pyproject.toml` file to install Maestro and its dependencies. For consistency, Apptainer should match. Updated base image of Apptainer build so that ROCm comes for free.